### PR TITLE
Includes and excludes not comma separated

### DIFF
--- a/src/main/java/com/github/ferstl/jarscan/JarScanMojo.java
+++ b/src/main/java/com/github/ferstl/jarscan/JarScanMojo.java
@@ -83,7 +83,7 @@ public class JarScanMojo extends AbstractMojo {
   private String scope;
 
   /**
-   * Comma-separated list of artifacts to be included in the form of {@code groupId:artifactId:type:classifier}. Only
+   * List of artifacts to be included in the form of {@code groupId:artifactId:type:classifier}. Only
    * relevant when {@code analyzeDependencies=true}.
    *
    * @since 1.0.0
@@ -92,7 +92,7 @@ public class JarScanMojo extends AbstractMojo {
   private List<String> includes;
 
   /**
-   * Comma-separated list of artifacts to be excluded in the form of {@code groupId:artifactId:type:classifier}. Only
+   * List of artifacts to be excluded in the form of {@code groupId:artifactId:type:classifier}. Only
    * relevant when {@code analyzeDependencies=true}.
    *
    * @since 1.0.0


### PR DESCRIPTION
From the plugin documentation I would expect the following works:

```xml
          <includes>
            <iclude>com.goldmansachs:gs-collections-api,com.goldmansachs:gs-collections</iclude>
          </includes>
```

However it has to look like this:

```xml
          <includes>
            <iclude>com.goldmansachs:gs-collections-api</iclude>
            <iclude>com.goldmansachs:gs-collections</iclude>
          </includes>
```